### PR TITLE
Add DolarHoy scraper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Codex
+
+Este repositorio incluye un script sencillo en Python para obtener las cotizaciones del Dólar Blue desde [dolarhoy.com](https://dolarhoy.com).
+
+## Uso
+
+1. Instala las dependencias necesarias:
+   ```bash
+   pip install requests beautifulsoup4
+   ```
+2. Ejecuta el script:
+   ```bash
+   python3 fetch_dolar.py
+   ```
+
+El programa imprimirá los valores de compra y venta obtenidos de la página.

--- a/fetch_dolar.py
+++ b/fetch_dolar.py
@@ -1,0 +1,18 @@
+import requests
+from bs4 import BeautifulSoup
+import re
+
+URL = "https://dolarhoy.com/cotizacion-dolar-blue"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+resp = requests.get(URL, headers=HEADERS)
+resp.raise_for_status()
+
+soup = BeautifulSoup(resp.text, 'html.parser')
+text = soup.get_text(" ", strip=True)
+prices = re.findall(r"\$\d+[.,]?\d*", text)
+if len(prices) >= 2:
+    print("Compra:", prices[0])
+    print("Venta:", prices[1])
+else:
+    print("No se encontraron precios en la página")


### PR DESCRIPTION
## Summary
- add a simple Python script that fetches Dólar Blue prices from dolarhoy.com
- update README with instructions

## Testing
- `python3 fetch_dolar.py`


------
https://chatgpt.com/codex/tasks/task_e_6842cc0faf408329ac495b2f43a5b16f