### PR TITLE
Add DolarBlue web generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Codex
+
+Este repositorio incluye scripts en Python para obtener las cotizaciones del Dólar Blue desde [dolarhoy.com](https://dolarhoy.com) y generar una página web que muestre el valor de forma vistosa.
+
+## Uso
+
+1. Instala las dependencias necesarias:
+   ```bash
+   pip install requests beautifulsoup4
+   ```
+2. Para imprimir los valores en consola ejecuta:
+   ```bash
+   python3 fetch_dolar.py
+   ```
+3. Para generar `index.html` con un video de fondo y el precio en pantalla completa ejecuta:
+   ```bash
+   python3 build_site.py
+   ```
+   Luego abre `index.html` en tu navegador.

--- a/build_site.py
+++ b/build_site.py
@@ -1,0 +1,44 @@
+import requests
+from bs4 import BeautifulSoup
+import re
+
+URL = "https://dolarhoy.com/cotizacion-dolar-blue"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+resp = requests.get(URL, headers=HEADERS)
+resp.raise_for_status()
+
+soup = BeautifulSoup(resp.text, 'html.parser')
+text = soup.get_text(" ", strip=True)
+prices = re.findall(r"\$\d+[.,]?\d*", text)
+if len(prices) >= 2:
+    buy = prices[0]
+    sell = prices[1]
+    value = f"Compra: {buy} | Venta: {sell}"
+else:
+    value = "Valor no encontrado"
+
+html = f"""
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8'>
+<title>Dólar Blue</title>
+<style>
+body,html {{ margin:0; padding:0; height:100%; overflow:hidden; }}
+#bgvideo {{ position:fixed; top:0; left:0; min-width:100%; min-height:100%; z-index:-1; object-fit:cover; }}
+#price {{ position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); color:#fff; font-size:6vw; font-family:Arial,sans-serif; text-shadow:0 0 10px #000; }}
+</style>
+</head>
+<body>
+<video id='bgvideo' autoplay muted loop>
+<source src='https://media.giphy.com/media/l0HlBO7eyXzSZkJri/giphy.mp4' type='video/mp4'>
+</video>
+<div id='price'>{value}</div>
+</body>
+</html>
+"""
+
+with open("index.html", "w", encoding="utf-8") as f:
+    f.write(html)
+print("index.html generado")

--- a/fetch_dolar.py
+++ b/fetch_dolar.py
@@ -1,0 +1,18 @@
+import requests
+from bs4 import BeautifulSoup
+import re
+
+URL = "https://dolarhoy.com/cotizacion-dolar-blue"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+resp = requests.get(URL, headers=HEADERS)
+resp.raise_for_status()
+
+soup = BeautifulSoup(resp.text, 'html.parser')
+text = soup.get_text(" ", strip=True)
+prices = re.findall(r"\$\d+[.,]?\d*", text)
+if len(prices) >= 2:
+    print("Compra:", prices[0])
+    print("Venta:", prices[1])
+else:
+    print("No se encontraron precios en la página")

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8'>
+<title>Dólar Blue</title>
+<style>
+body,html { margin:0; padding:0; height:100%; overflow:hidden; }
+#bgvideo { position:fixed; top:0; left:0; min-width:100%; min-height:100%; z-index:-1; object-fit:cover; }
+#price { position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); color:#fff; font-size:6vw; font-family:Arial,sans-serif; text-shadow:0 0 10px #000; }
+</style>
+</head>
+<body>
+<video id='bgvideo' autoplay muted loop>
+<source src='https://media.giphy.com/media/l0HlBO7eyXzSZkJri/giphy.mp4' type='video/mp4'>
+</video>
+<div id='price'>Compra: $1155,00 | Venta: $1175,00</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update README with new instructions
- add `build_site.py` to generate a full-screen web page with a finance-themed video background
- include generated `index.html`

## Testing
- `python3 fetch_dolar.py`
- `python3 build_site.py`


------
https://chatgpt.com/codex/tasks/task_e_6842cc0faf408329ac495b2f43a5b16f